### PR TITLE
group configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ hosts:
   default:
     username: admin
     password: pass
+groups:
+  group1:
+    username: group1_user
+    password: group1_pass
 ```
 Note that the ```default`` entry is useful as it avoids an error
 condition that is discussed in [this issue][2].
@@ -76,6 +80,9 @@ something like this in your Prometheus configuration files:
         target_label: instance
       - target_label: __address__
         replacement: localhost:9610  ### the address of the redfish-exporter address
+      # (optional) when using group config add this to have group=my_group_name
+      - target_label: __param_group
+        replacement: my_group_name
 ```
 Note that port 9610 has been [reserved][4] for the redfish_exporter.
 ## Supported Devices (tested)

--- a/config.go
+++ b/config.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Config struct {
-	Hosts map[string]HostConfig `yaml:"hosts"`
+	Hosts  map[string]HostConfig `yaml:"hosts"`
+	Groups map[string]HostConfig `yaml:"groups"`
 }
 
 type SafeConfig struct {
@@ -56,4 +57,15 @@ func (sc *SafeConfig) HostConfigForTarget(target string) (*HostConfig, error) {
 		}, nil
 	}
 	return &HostConfig{}, fmt.Errorf("no credentials found for target %s", target)
+}
+
+// HostConfigForGroup checks the configuration for a matching group config and returns the configured HostConfig for
+// that matched group.
+func (sc *SafeConfig) HostConfigForGroup(group string) (*HostConfig, error) {
+	sc.Lock()
+	defer sc.Unlock()
+	if hostConfig, ok := sc.C.Groups[group]; ok {
+		return &hostConfig, nil
+	}
+	return &HostConfig{}, fmt.Errorf("no credentials found for group %s", group)
 }

--- a/config.yml.example
+++ b/config.yml.example
@@ -5,3 +5,7 @@ hosts:
   192.168.100.1:
     username: different_user
     password: different_pass 
+groups:
+  group1:
+    username: group1_user
+    password: group1_pass


### PR DESCRIPTION
This PR adds the option to configure groups of hosts with identical username/password. It makes it easier to work with different groups of hosts using the same credentials without having to run multiple instances of this exporter.

It doesn't change the original functionality but extends the configuration of the `groups` part. The group configuration is only used if `group` GET parameter has been set (see README for how this is done in Prometheus). If no group config has been found the existing host config is also checked.