### PR TITLE
feat: add http endpoint for reloading config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,17 @@ curl http://<redfish_exporter host>:9610/redfish?target=10.36.48.24
 ```
 or by pointing your favourite browser at this URL.
 
-## prometheus configuration
+## Reloading Configuration
+```
+PUT /-/reload
+POST /-/reload
+```
+The `/-/reload` endpoint triggers a reload of the redfish_exporter configuration.
+500 will be returned when the reload fails.
+
+Alternatively, a configuration reload can be triggered by sending `SIGHUP` to the redfish_exporter process as well.
+
+## Prometheus Configuration
 
 You can then setup [Prometheus][3] to scrape the target using
 something like this in your Prometheus configuration files:


### PR DESCRIPTION
The added endpoint `/-/reload` triggers a reload of the redfish_exporter configuration when receiving a PUT or POST request.
This was inspired by the same feature in prometheus(see [docs](https://github.com/prometheus/prometheus/blob/main/docs/management_api.md#reload))

Closes: https://github.com/jenningsloy318/redfish_exporter/issues/35