### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/centos:8 AS builder
+FROM golang:rc-bullseye AS builder
 
 LABEL maintainer="Jennings Liu <jenningsloy318@gmail.com>"
 
@@ -12,20 +12,14 @@ ENV GO111MODULE=on
 
 
 # Build dependencies
-
-RUN yum update -y && \
-    yum install -y  rpm-build make  git && \
-    curl -SL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -xzC /usr/local 
 RUN mkdir -p /go/src/github.com/ && \
     git clone https://github.com/jenningsloy318/redfish_exporter /go/src/github.com/jenningsloy318/redfish_exporter && \
     cd /go/src/github.com/jenningsloy318/redfish_exporter && \
     make build
 
-FROM docker.io/library/centos:8 
+FROM golang:rc-bullseye
 
 COPY --from=builder /go/src/github.com/jenningsloy318/redfish_exporter/build/redfish_exporter /usr/local/bin/redfish_exporter
 RUN mkdir /etc/prometheus
 COPY config.yml.example /etc/prometheus/redfish_exporter.yml
 CMD ["/usr/local/bin/redfish_exporter","--config.file","/etc/prometheus/redfish_exporter.yml"]
-
-


### PR DESCRIPTION
Update to use the official golang image, centos8 is EOL. Golang image is also lighter and already comes with preinstalled dependencies.