### PR TITLE
fix: collector_duration_seconds metric

### DIFF
--- a/collector/redfish_collector.go
+++ b/collector/redfish_collector.go
@@ -86,13 +86,13 @@ func (r *RedfishCollector) Collect(ch chan<- prometheus.Metric) {
 		wg := &sync.WaitGroup{}
 		wg.Add(len(r.collectors))
 
-		defer wg.Wait()
 		for _, collector := range r.collectors {
 			go func(collector prometheus.Collector) {
 				defer wg.Done()
 				collector.Collect(ch)
 			}(collector)
 		}
+		wg.Wait()
 	} else {
 		r.redfishUp.Set(0)
 	}


### PR DESCRIPTION
This PR fixes the collector_duration_seconds metric measurement.

In the original code, the metric value is calculated right after the collector's goroutines started, as the `wg.Wait` happens only after `RedfishCollector.Collect` returns.
So the collector_duration_seconds's value was always in the order of milliseconds, even though the goroutines took 10's of seconds to return.