### PR TITLE
Collect fan low/hi RPMs thresholds and properly compute fan percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Note that port 9610 has been [reserved][4] for the redfish_exporter.
 ## Supported Devices (tested)
 - Lenovo ThinkSystem SR850 (BMC 2.1/2.42)
 - Lenovo ThinkSystem SR650 (BMC 2.50)
-- PowerEdge R440 
+- Dell PowerEdge R440, R640, R650, R6515, C6420
+- GIGABYTE G292-Z20, G292-Z40, G482-Z54
+
 ## Acknowledgement
 
 - [gofish][5] provides the underlying library to interact servers


### PR DESCRIPTION
The `chassis_fan_rpm` metric (aka Reading) currently assumes that the reported fan value unit is a percentage, whereas the unit is informed by the ReadingUnits. To fix this I've added a `chassis_fan_rpm_percentage` metric that reports this percentage, regardless of whether the unit is RPM or Percentage, and added a `fan_unit` label to the original `chassis_fan_rpm` metric to indicate what unit the raw value is. (this means the `chassis_fan_rpm` metric won't change for users)

In addition, I've also exported the Min/MaxReadingRange, LowerThresholdCritical, LowerThresholdNonCritical, LowerThresholdFatal, UpperThresholdCritical, UpperThresholdNonCritical, and UpperThresholdFatal values. I've seen these be null for some servers though.

I've added some of the devices I tested on to the README. I'm assuming "supported" doesn't mean all values are non-null, just that the exporter works on them and exports all possible metrics.

Closes #42

As an aside, many thanks for this piece of software, it has been extremely useful for me!