### PR TITLE
Add log service metrics for manager, chassis and system

### DIFF
--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -22,291 +22,67 @@ var (
 	ChassisPowerVoltageLabelNames     = []string{"resource", "chassis_id", "power_voltage", "power_voltage_id"}
 	ChassisPowerSupplyLabelNames      = []string{"resource", "chassis_id", "power_supply", "power_supply_id"}
 	ChassisNetworkAdapterLabelNames   = []string{"resource", "chassis_id", "network_adapter", "network_adapter_id"}
-	ChassisNetworkPortLabelNames      = []string{"resource", "chassis_id", "network_adapter", "network_adapter_id", "network_port", "network_port_id", "network_port_type", "network_port_speed","network_port_connectiont_type","network_physical_port_number"}
+	ChassisNetworkPortLabelNames      = []string{"resource", "chassis_id", "network_adapter", "network_adapter_id", "network_port", "network_port_id", "network_port_type", "network_port_speed", "network_port_connectiont_type", "network_physical_port_number"}
 	ChassisPhysicalSecurityLabelNames = []string{"resource", "chassis_id", "intrusion_sensor_number", "intrusion_sensor_rearm"}
 
-	chassisMetrics = map[string]chassisMetric{
-		"chassis_health": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "health"),
-				"health of chassis, 1(OK),2(Warning),3(Critical)",
-				ChassisLabelNames,
-				nil,
-			),
-		},
-		"chassis_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "state"),
-				"state of chassis,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisLabelNames,
-				nil,
-			),
-		},
-		"chassis_model_info": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "model_info"),
-				"organization responsible for producing the chassis, the name by which the manufacturer generally refers to the chassis, and a part number and sku assigned by the organization that is responsible for producing or manufacturing the chassis",
-				ChassisModel,
-				nil,
-			),
-		},
-		"chassis_temperature_sensor_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "temperature_sensor_state"),
-				"status state of temperature on this chassis component,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisTemperatureLabelNames,
-				nil,
-			),
-		},
-		"chassis_temperature_celsius": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "temperature_celsius"),
-				"celsius of temperature on this chassis component",
-				ChassisTemperatureLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_health": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_health"),
-				"fan health on this chassis component,1(OK),2(Warning),3(Critical)",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_state"),
-				"fan state on this chassis component,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm"),
-				"fan RPM or percentage on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_percentage": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_percentage"),
-				"fan RPM, as a percentage of the min-max RPMs possible, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_min": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_min"),
-				"lowest possible fan RPM or percentage, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_max": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_max"),
-				"highest possible fan RPM or percentage, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_lower_threshold_critical": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_lower_threshold_critical"),
-				"threshold below the normal range fan RPM or percentage, but not fatal, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_lower_threshold_non_critical": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_lower_threshold_non_critical"),
-				"threshold below the normal range fan RPM or percentage, but not critical, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_lower_threshold_fatal": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_lower_threshold_fatal"),
-				"threshold below the normal range fan RPM or percentage, and is fatal, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_upper_threshold_critical": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_upper_threshold_critical"),
-				"threshold above the normal range fan RPM or percentage, but not fatal, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_upper_threshold_non_critical": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_upper_threshold_non_critical"),
-				"threshold above the normal range fan RPM or percentage, but not critical, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_fan_rpm_upper_threshold_fatal": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "fan_rpm_upper_threshold_fatal"),
-				"threshold above the normal range fan RPM or percentage, and is fatal, on this chassis component",
-				ChassisFanLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_voltage_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_voltage_state"),
-				"power voltage state of chassis component,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisPowerVoltageLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_voltage_volts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_voltage_volts"),
-				"power voltage volts number of chassis component",
-				ChassisPowerVoltageLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_average_consumed_watts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_average_consumed_watts"),
-				"power wattage watts number of chassis component",
-				ChassisPowerVoltageLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_state"),
-				"powersupply state of chassis component,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_health": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_health"),
-				"powersupply health of chassis component,1(OK),2(Warning),3(Critical)",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_power_efficiency_percentage": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_power_efficiency_percentage"),
-				"rated efficiency, as a percentage, of the associated power supply on this chassis",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_last_power_output_watts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_last_power_output_watts"),
-				"average power output, measured in Watts, of the associated power supply on this chassis",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_power_input_watts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_power_input_watts"),
-				"measured input power, in Watts, of powersupply on this chassis",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_power_output_watts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_power_output_watts"),
-				"measured output power, in Watts, of powersupply on this chassis",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_power_powersupply_power_capacity_watts": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "power_powersupply_power_capacity_watts"),
-				"power_capacity_watts of powersupply on this chassis",
-				ChassisPowerSupplyLabelNames,
-				nil,
-			),
-		},
-		"chassis_network_adapter_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "network_adapter_state"),
-				"chassis network adapter state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisNetworkAdapterLabelNames,
-				nil,
-			),
-		},
-		"chassis_network_adapter_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "network_adapter_health_state"),
-				"chassis network adapter health state,1(OK),2(Warning),3(Critical)",
-				ChassisNetworkAdapterLabelNames,
-				nil,
-			),
-		},
-		"chassis_network_port_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "network_port_state"),
-				"chassis network port state state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				ChassisNetworkPortLabelNames,
-				nil,
-			),
-		},
-		"chassis_network_port_link_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "network_port_link_state"),
-				"chassis network port link state state,1(Up),0(Down)",
-				ChassisNetworkPortLabelNames,
-				nil,
-			),
-		},
-		"chassis_network_port_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "network_port_health_state"),
-				"chassis network port state state,1(OK),2(Warning),3(Critical)",
-				ChassisNetworkPortLabelNames,
-				nil,
-			),
-		},
-		"chassis_physical_security_sensor_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, ChassisSubsystem, "physical_security_sensor_state"),
-				"indicates the known state of the physical security sensor, such as if it is hardware intrusion detected, 1(Normal),2(TamperingDetected),3(HardwareIntrusion)",
-				ChassisPhysicalSecurityLabelNames,
-				nil,
-			),
-		},
-	}
+	chassisMetrics = createChassisMetricMap()
 )
 
 // ChassisCollector implements the prometheus.Collector.
 type ChassisCollector struct {
 	redfishClient         *gofish.APIClient
-	metrics               map[string]chassisMetric
+	metrics               map[string]Metric
 	collectorScrapeStatus *prometheus.GaugeVec
 	Log                   *log.Entry
 }
 
-type chassisMetric struct {
-	desc *prometheus.Desc
+func createChassisMetricMap() map[string]Metric {
+	chassisMetrics := make(map[string]Metric)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "health", fmt.Sprintf("health of chassis,%s", CommonHealthHelp), ChassisLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "state", fmt.Sprintf("state of chassis,%s", CommonStateHelp), ChassisLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "model_info", "organization responsible for producing the chassis, the name by which the manufacturer generally refers to the chassis, and a part number and sku assigned by the organization that is responsible for producing or manufacturing the chassis", ChassisModel)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "temperature_sensor_state", fmt.Sprintf("status state of temperature on this chassis component,%s", CommonStateHelp), ChassisTemperatureLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "temperature_celsius", "celsius of temperature on this chassis component", ChassisTemperatureLabelNames)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_health", fmt.Sprintf("fan health on this chassis component,%s", CommonHealthHelp), ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_state", fmt.Sprintf("fan state on this chassis component,%s", CommonStateHelp), ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm", "fan RPM or percentage on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_percentage", "fan RPM, as a percentage of the min-max RPMs possible, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_min", "lowest possible fan RPM or percentage, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_max", "highest possible fan RPM or percentage, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_lower_threshold_critical", "threshold below the normal range fan RPM or percentage, but not fatal, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_lower_threshold_non_critical", "threshold below the normal range fan RPM or percentage, but not critical, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_lower_threshold_fatal", "threshold below the normal range fan RPM or percentage, and is fatal, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_upper_threshold_critical", "threshold above the normal range fan RPM or percentage, but not fatal, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_upper_threshold_non_critical", "threshold above the normal range fan RPM or percentage, but not critical, on this chassis component", ChassisFanLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "fan_rpm_upper_threshold_fatal", "threshold above the normal range fan RPM or percentage, and is fatal, on this chassis component", ChassisFanLabelNames)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_voltage_state", fmt.Sprintf("power voltage state of chassis component,%s", CommonStateHelp), ChassisPowerVoltageLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_voltage_volts", "power voltage volts number of chassis component", ChassisPowerVoltageLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_average_consumed_watts", "power wattage watts number of chassis component", ChassisPowerVoltageLabelNames)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_state", fmt.Sprintf("powersupply state of chassis component,%s", CommonStateHelp), ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_health", fmt.Sprintf("powersupply health of chassis component,%s", CommonHealthHelp), ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_power_efficiency_percentage", "rated efficiency, as a percentage, of the associated power supply on this chassis", ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_last_power_output_watts", "average power output, measured in Watts, of the associated power supply on this chassis", ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_power_input_watts", "measured input power, in Watts, of powersupply on this chassis", ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_power_output_watts", "measured output power, in Watts, of powersupply on this chassis", ChassisPowerSupplyLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "power_powersupply_power_capacity_watts", "power_capacity_watts of powersupply on this chassis", ChassisPowerSupplyLabelNames)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "network_adapter_state", fmt.Sprintf("chassis network adapter state,%s", CommonStateHelp), ChassisNetworkAdapterLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "network_adapter_health_state", fmt.Sprintf("chassis network adapter health state,%s", CommonHealthHelp), ChassisNetworkAdapterLabelNames)
+
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "network_port_state", fmt.Sprintf("chassis network port state,%s", CommonStateHelp), ChassisNetworkPortLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "network_port_health_state", fmt.Sprintf("chassis network port health state,%s", CommonHealthHelp), ChassisNetworkPortLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "network_port_link_state", fmt.Sprintf("chassis network port link state state,%s", CommonPortLinkHelp), ChassisNetworkPortLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "physical_security_sensor_state", fmt.Sprintf("indicates the known state of the physical security sensor, such as if it is hardware intrusion detected,%s", CommonIntrusionSensorHelp), ChassisPhysicalSecurityLabelNames)
+
+	return chassisMetrics
 }
 
 // NewChassisCollector returns a collector that collecting chassis statistics
-func NewChassisCollector(namespace string, redfishClient *gofish.APIClient, logger *log.Entry) *ChassisCollector {
+func NewChassisCollector(redfishClient *gofish.APIClient, logger *log.Entry) *ChassisCollector {
 	// get service from redfish client
 
 	return &ChassisCollector{
@@ -404,7 +180,6 @@ func (c *ChassisCollector) Collect(ch chan<- prometheus.Metric) {
 				wg3.Add(len(chassisPowerInfoVoltages))
 				for _, chassisPowerInfoVoltage := range chassisPowerInfoVoltages {
 					go parseChassisPowerInfoVoltage(ch, chassisID, chassisPowerInfoVoltage, wg3)
-
 				}
 
 				// power control
@@ -420,7 +195,6 @@ func (c *ChassisCollector) Collect(ch chan<- prometheus.Metric) {
 				wg5 := &sync.WaitGroup{}
 				wg5.Add(len(chassisPowerInfoPowerSupplies))
 				for _, chassisPowerInfoPowerSupply := range chassisPowerInfoPowerSupplies {
-
 					go parseChassisPowerInfoPowerSupply(ch, chassisID, chassisPowerInfoPowerSupply, wg5)
 				}
 			}
@@ -452,9 +226,9 @@ func (c *ChassisCollector) Collect(ch chan<- prometheus.Metric) {
 				if phySecIntrusionSensor, ok := parsePhySecIntrusionSensor(physicalSecurityIntrusionSensor); ok {
 					ChassisPhysicalSecurityLabelValues := []string{"physical_security", chassisID, physicalSecurityIntrusionSensorNumber, physicalSecurityIntrusionSensorReArmMethod}
 					ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_physical_security_sensor_state"].desc, prometheus.GaugeValue, phySecIntrusionSensor, ChassisPhysicalSecurityLabelValues...)
-
 				}
 			}
+
 			chassisLogContext.Info("collector scrape completed")
 		}
 	}
@@ -480,6 +254,7 @@ func parseChassisTemperature(ch chan<- prometheus.Metric, chassisID string, chas
 	chassisTemperatureReadingCelsius := chassisTemperature.ReadingCelsius
 	ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_celsius"].desc, prometheus.GaugeValue, float64(chassisTemperatureReadingCelsius), chassisTemperatureLabelvalues...)
 }
+
 func parseChassisFan(ch chan<- prometheus.Metric, chassisID string, chassisFan redfish.Fan, wg *sync.WaitGroup) {
 	defer wg.Done()
 	chassisFanID := chassisFan.MemberID
@@ -542,6 +317,7 @@ func parseChassisPowerInfoVoltage(ch chan<- prometheus.Metric, chassisID string,
 	}
 	ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_power_voltage_volts"].desc, prometheus.GaugeValue, float64(chassisPowerInfoVoltageNameReadingVolts), chassisPowerVoltageLabelvalues...)
 }
+
 func parseChassisPowerInfoPowerControl(ch chan<- prometheus.Metric, chassisID string, chassisPowerInfoPowerControl redfish.PowerControl, wg *sync.WaitGroup) {
 	defer wg.Done()
 	name := chassisPowerInfoPowerControl.Name
@@ -552,7 +328,6 @@ func parseChassisPowerInfoPowerControl(ch chan<- prometheus.Metric, chassisID st
 }
 
 func parseChassisPowerInfoPowerSupply(ch chan<- prometheus.Metric, chassisID string, chassisPowerInfoPowerSupply redfish.PowerSupply, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 	chassisPowerInfoPowerSupplyName := chassisPowerInfoPowerSupply.Name
 	chassisPowerInfoPowerSupplyID := chassisPowerInfoPowerSupply.MemberID
@@ -579,7 +354,6 @@ func parseChassisPowerInfoPowerSupply(ch chan<- prometheus.Metric, chassisID str
 }
 
 func parseNetworkAdapter(ch chan<- prometheus.Metric, chassisID string, networkAdapter *redfish.NetworkAdapter, wg *sync.WaitGroup) error {
-
 	defer wg.Done()
 	networkAdapterName := networkAdapter.Name
 	networkAdapterID := networkAdapter.ID
@@ -610,19 +384,18 @@ func parseNetworkPort(ch chan<- prometheus.Metric, chassisID string, networkPort
 	networkPortName := networkPort.Name
 	networkPortID := networkPort.ID
 	networkPortState := networkPort.Status.State
-	networkLinkStatus :=networkPort.LinkStatus
+	networkLinkStatus := networkPort.LinkStatus
 	networkPortLinkType := networkPort.ActiveLinkTechnology
 	networkPortLinkSpeed := fmt.Sprintf("%d Mbps", networkPort.CurrentLinkSpeedMbps)
 	networkPortHealthState := networkPort.Status.Health
-	networkPortConnectionType :=networkPort.FCPortConnectionType
-	networkPhysicalPortNumber :=networkPort.PhysicalPortNumber
-	chassisNetworkPortLabelValues := []string{"network_port", chassisID, networkAdapterName, networkAdapterID, networkPortName, networkPortID, string(networkPortLinkType), networkPortLinkSpeed,string(networkPortConnectionType),networkPhysicalPortNumber}
-	
-	if networkLinkStatusValue,ok := parsePortLinkStatus(networkLinkStatus);ok {
-		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_network_port_link_state"].desc, prometheus.GaugeValue, networkLinkStatusValue, chassisNetworkPortLabelValues...)
+	networkPortConnectionType := networkPort.FCPortConnectionType
+	networkPhysicalPortNumber := networkPort.PhysicalPortNumber
+	chassisNetworkPortLabelValues := []string{"network_port", chassisID, networkAdapterName, networkAdapterID, networkPortName, networkPortID, string(networkPortLinkType), networkPortLinkSpeed, string(networkPortConnectionType), networkPhysicalPortNumber}
 
+	if networkLinkStatusValue, ok := parsePortLinkStatus(networkLinkStatus); ok {
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_network_port_link_state"].desc, prometheus.GaugeValue, networkLinkStatusValue, chassisNetworkPortLabelValues...)
 	}
-	
+
 	if networkPortStateValue, ok := parseCommonStatusState(networkPortState); ok {
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_network_port_state"].desc, prometheus.GaugeValue, networkPortStateValue, chassisNetworkPortLabelValues...)
 	}

--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -227,7 +227,7 @@ func (c *ChassisCollector) Collect(ch chan<- prometheus.Metric) {
 			physicalSecurity := chassis.PhysicalSecurity
 			if physicalSecurity != (redfish.PhysicalSecurity{}) {
 				physicalSecurityIntrusionSensor := physicalSecurity.IntrusionSensor
-				physicalSecurityIntrusionSensorNumber := fmt.Sprintf("%d", physicalSecurity.IntrusionSensorNumber)
+				physicalSecurityIntrusionSensorNumber := fmt.Sprint(physicalSecurity.IntrusionSensorNumber)
 				physicalSecurityIntrusionSensorReArmMethod := string(physicalSecurity.IntrusionSensorReArm)
 
 				if phySecIntrusionSensor, ok := parsePhySecIntrusionSensor(physicalSecurityIntrusionSensor); ok {

--- a/collector/common_collector.go
+++ b/collector/common_collector.go
@@ -37,7 +37,7 @@ func parseLogService(ch chan<- prometheus.Metric, metrics map[string]Metric, sub
 	defer wg.Done()
 	logServiceName := logService.Name
 	logServiceID := logService.ID
-	logServiceEnabled := fmt.Sprintf("%t", logService.ServiceEnabled)
+	logServiceEnabled := fmt.Sprint(logService.ServiceEnabled)
 	logServiceOverWritePolicy := string(logService.OverWritePolicy)
 	logServiceState := logService.Status.State
 	logServiceHealthState := logService.Status.Health
@@ -70,7 +70,7 @@ func parseLogEntry(ch chan<- prometheus.Metric, desc *prometheus.Desc, collector
 	logEntryCode := string(logEntry.EntryCode)
 	logEntryType := string(logEntry.EntryType)
 	logEntryMessageID := logEntry.MessageID
-	logEntrySensorNumber := fmt.Sprintf("%d", logEntry.SensorNumber)
+	logEntrySensorNumber := fmt.Sprint(logEntry.SensorNumber)
 	logEntrySensorType := string(logEntry.SensorType)
 	logEntrySeverityState := logEntry.Severity
 

--- a/collector/common_collector.go
+++ b/collector/common_collector.go
@@ -1,0 +1,32 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	CommonStateHelp           = "1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)"
+	CommonHealthHelp          = "1(OK),2(Warning),3(Critical)"
+	CommonSeverityHelp        = CommonHealthHelp
+	CommonLinkHelp            = "1(LinkUp),2(NoLink),3(LinkDown)"
+	CommonPortLinkHelp        = "1(Up),0(Down)"
+	CommonIntrusionSensorHelp = "1(Normal),2(TamperingDetected),3(HardwareIntrusion)"
+)
+
+type Metric struct {
+	desc *prometheus.Desc
+}
+
+func addToMetricMap(metricMap map[string]Metric, subsystem, name, help string, variableLabels []string) {
+	metricKey := fmt.Sprintf("%s_%s", subsystem, name)
+	metricMap[metricKey] = Metric{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, subsystem, name),
+			help,
+			variableLabels,
+			nil,
+		),
+	}
+}

--- a/collector/common_collector.go
+++ b/collector/common_collector.go
@@ -2,8 +2,10 @@ package collector
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stmcginnis/gofish/redfish"
 )
 
 const (
@@ -28,5 +30,53 @@ func addToMetricMap(metricMap map[string]Metric, subsystem, name, help string, v
 			variableLabels,
 			nil,
 		),
+	}
+}
+
+func parseLogService(ch chan<- prometheus.Metric, metrics map[string]Metric, subsystem, collectorID string, logService *redfish.LogService, wg *sync.WaitGroup) (err error) {
+	defer wg.Done()
+	logServiceName := logService.Name
+	logServiceID := logService.ID
+	logServiceEnabled := fmt.Sprintf("%t", logService.ServiceEnabled)
+	logServiceOverWritePolicy := string(logService.OverWritePolicy)
+	logServiceState := logService.Status.State
+	logServiceHealthState := logService.Status.Health
+
+	logServiceLabelValues := []string{collectorID, logServiceName, logServiceID, logServiceEnabled, logServiceOverWritePolicy}
+
+	if logServiceStateValue, ok := parseCommonStatusState(logServiceState); ok {
+		ch <- prometheus.MustNewConstMetric(metrics[fmt.Sprintf("%s_%s", subsystem, "log_service_state")].desc, prometheus.GaugeValue, logServiceStateValue, logServiceLabelValues...)
+	}
+	if logServiceHealthStateValue, ok := parseCommonStatusHealth(logServiceHealthState); ok {
+		ch <- prometheus.MustNewConstMetric(metrics[fmt.Sprintf("%s_%s", subsystem, "log_service_health_state")].desc, prometheus.GaugeValue, logServiceHealthStateValue, logServiceLabelValues...)
+	}
+
+	logEntries, err := logService.Entries()
+	if err != nil {
+		return
+	}
+	wg2 := &sync.WaitGroup{}
+	wg2.Add(len(logEntries))
+	for _, logEntry := range logEntries {
+		go parseLogEntry(ch, metrics[fmt.Sprintf("%s_%s", subsystem, "log_entry_severity_state")].desc, collectorID, logServiceName, logServiceID, logEntry, wg2)
+	}
+	return
+}
+
+func parseLogEntry(ch chan<- prometheus.Metric, desc *prometheus.Desc, collectorID, logServiceName, logServiceID string, logEntry *redfish.LogEntry, wg *sync.WaitGroup) {
+	defer wg.Done()
+	logEntryName := logEntry.Name
+	logEntryID := logEntry.ID
+	logEntryCode := string(logEntry.EntryCode)
+	logEntryType := string(logEntry.EntryType)
+	logEntryMessageID := logEntry.MessageID
+	logEntrySensorNumber := fmt.Sprintf("%d", logEntry.SensorNumber)
+	logEntrySensorType := string(logEntry.SensorType)
+	logEntrySeverityState := logEntry.Severity
+
+	logEntryLabelValues := []string{collectorID, logServiceName, logServiceID, logEntryName, logEntryID, logEntryCode, logEntryType, logEntryMessageID, logEntrySensorNumber, logEntrySensorType}
+
+	if logEntrySeverityStateValue, ok := parseCommonSeverityState(logEntrySeverityState); ok {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, logEntrySeverityStateValue, logEntryLabelValues...)
 	}
 }

--- a/collector/manager_collector.go
+++ b/collector/manager_collector.go
@@ -86,7 +86,7 @@ func (m *ManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			ManagerID := manager.ID
 			managerName := manager.Name
 			managerModel := manager.Model
-			managerType := fmt.Sprintf("%v", manager.ManagerType)
+			managerType := fmt.Sprint(manager.ManagerType)
 			managerPowerState := manager.PowerState
 			managerState := manager.Status.State
 			managerHealthState := manager.Status.Health

--- a/collector/manager_collector.go
+++ b/collector/manager_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/apex/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,6 +13,9 @@ import (
 var (
 	ManagerSubmanager = "manager"
 	ManagerLabelNames = []string{"manager_id", "name", "model", "type"}
+
+	ManagerLogServiceLabelNames = []string{"manager_id", "log_service", "log_service_id", "log_service_enabled", "log_service_overwrite_policy"}
+	ManagerLogEntryLabelNames   = []string{"manager_id", "log_service", "log_service_id", "log_entry", "log_entry_id", "log_entry_code", "log_entry_type", "log_entry_message_id", "log_entry_sensor_number", "log_entry_sensor_type"}
 
 	managerMetrics = createManagerMetricMap()
 )
@@ -29,6 +33,10 @@ func createManagerMetricMap() map[string]Metric {
 	addToMetricMap(managerMetrics, ManagerSubmanager, "state", fmt.Sprintf("manager state,%s", CommonStateHelp), ManagerLabelNames)
 	addToMetricMap(managerMetrics, ManagerSubmanager, "health_state", fmt.Sprintf("manager health,%s", CommonHealthHelp), ManagerLabelNames)
 	addToMetricMap(managerMetrics, ManagerSubmanager, "power_state", "manager power state", ManagerLabelNames)
+
+	addToMetricMap(managerMetrics, ManagerSubmanager, "log_service_state", fmt.Sprintf("manager log service state,%s", CommonStateHelp), ManagerLogServiceLabelNames)
+	addToMetricMap(managerMetrics, ManagerSubmanager, "log_service_health_state", fmt.Sprintf("manager log service health state,%s", CommonHealthHelp), ManagerLogServiceLabelNames)
+	addToMetricMap(managerMetrics, ManagerSubmanager, "log_entry_severity_state", fmt.Sprintf("manager log entry severity state,%s", CommonSeverityHelp), ManagerLogEntryLabelNames)
 
 	return managerMetrics
 }
@@ -93,7 +101,23 @@ func (m *ManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			if managerPowerStateValue, ok := parseCommonPowerState(managerPowerState); ok {
 				ch <- prometheus.MustNewConstMetric(m.metrics["manager_power_state"].desc, prometheus.GaugeValue, managerPowerStateValue, ManagerLabelValues...)
+			}
 
+			// process log services
+			logServices, err := manager.LogServices()
+			if err != nil {
+				managerLogContext.WithField("operation", "manager.LogServices()").WithError(err).Error("error getting log services from manager")
+			} else if logServices == nil {
+				managerLogContext.WithField("operation", "manager.LogServices()").Info("no log services found")
+			} else {
+				wg := &sync.WaitGroup{}
+				wg.Add(len(logServices))
+
+				for _, logService := range logServices {
+					if err = parseLogService(ch, managerMetrics, ManagerSubmanager, ManagerID, logService, wg); err != nil {
+						managerLogContext.WithField("operation", "manager.LogServices()").WithError(err).Error("error getting log entries from log service")
+					}
+				}
 			}
 
 			managerLogContext.Info("collector scrape completed")

--- a/collector/redfish_collector.go
+++ b/collector/redfish_collector.go
@@ -159,6 +159,17 @@ func parseCommonStatusState(status gofishcommon.State) (float64, bool) {
 	return float64(0), false
 }
 
+func parseCommonSeverityState(severity redfish.EventSeverity) (float64, bool) {
+	if bytes.Equal([]byte(severity), []byte("OK")) {
+		return float64(1), true
+	} else if bytes.Equal([]byte(severity), []byte("Warning")) {
+		return float64(2), true
+	} else if bytes.Equal([]byte(severity), []byte("Critical")) {
+		return float64(3), true
+	}
+	return float64(0), false
+}
+
 func parseCommonPowerState(status redfish.PowerState) (float64, bool) {
 	if bytes.Equal([]byte(status), []byte("On")) {
 		return float64(1), true

--- a/collector/redfish_collector.go
+++ b/collector/redfish_collector.go
@@ -47,9 +47,9 @@ func NewRedfishCollector(host string, username string, password string, logger *
 	if err != nil {
 		collectorLogCtx.WithError(err).Error("error creating redfish client")
 	} else {
-		chassisCollector := NewChassisCollector(namespace, redfishClient, collectorLogCtx)
-		systemCollector := NewSystemCollector(namespace, redfishClient, collectorLogCtx)
-		managerCollector := NewManagerCollector(namespace, redfishClient, collectorLogCtx)
+		chassisCollector := NewChassisCollector(redfishClient, collectorLogCtx)
+		systemCollector := NewSystemCollector(redfishClient, collectorLogCtx)
+		managerCollector := NewManagerCollector(redfishClient, collectorLogCtx)
 
 		collectors = map[string]prometheus.Collector{"chassis": chassisCollector, "system": systemCollector, "manager": managerCollector}
 	}
@@ -186,7 +186,7 @@ func parseLinkStatus(status redfish.LinkStatus) (float64, bool) {
 func parsePortLinkStatus(status redfish.PortLinkStatus) (float64, bool) {
 	if bytes.Equal([]byte(status), []byte("Up")) {
 		return float64(1), true
-	} 
+	}
 	return float64(0), false
 }
 func boolToFloat64(data bool) float64 {

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -503,7 +503,7 @@ func parseEthernetInterface(ch chan<- prometheus.Metric, systemHostName string, 
 func parsePcieFunction(ch chan<- prometheus.Metric, systemHostName string, pcieFunction *redfish.PCIeFunction, wg *sync.WaitGroup) {
 	defer wg.Done()
 	pcieFunctionName := pcieFunction.Name
-	pcieFunctionID := fmt.Sprint("%v", pcieFunction.ID)
+	pcieFunctionID := fmt.Sprintf("%v", pcieFunction.ID)
 	pciFunctionDeviceclass := fmt.Sprintf("%v", pcieFunction.DeviceClass)
 	pciFunctionType := fmt.Sprintf("%v", pcieFunction.FunctionType)
 	pciFunctionState := pcieFunction.Status.State

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -471,7 +471,7 @@ func parsePcieDevice(ch chan<- prometheus.Metric, systemHostName string, pcieDev
 	pcieDeviceState := pcieDevice.Status.State
 	pcieDeviceHealthState := pcieDevice.Status.Health
 	pcieDevicePartNumber := pcieDevice.PartNumber
-	pcieDeviceType := fmt.Sprintf("%v,", pcieDevice.DeviceType)
+	pcieDeviceType := fmt.Sprint(pcieDevice.DeviceType)
 	pcieSerialNumber := pcieDevice.SerialNumber
 	systemPCIeDeviceLabelValues := []string{systemHostName, "pcie_device", pcieDeviceName, pcieDeviceID, pcieDevicePartNumber, pcieDeviceType, pcieSerialNumber}
 
@@ -527,9 +527,9 @@ func parseEthernetInterface(ch chan<- prometheus.Metric, systemHostName string, 
 func parsePcieFunction(ch chan<- prometheus.Metric, systemHostName string, pcieFunction *redfish.PCIeFunction, wg *sync.WaitGroup) {
 	defer wg.Done()
 	pcieFunctionName := pcieFunction.Name
-	pcieFunctionID := fmt.Sprintf("%v", pcieFunction.ID)
-	pciFunctionDeviceclass := fmt.Sprintf("%v", pcieFunction.DeviceClass)
-	pciFunctionType := fmt.Sprintf("%v", pcieFunction.FunctionType)
+	pcieFunctionID := fmt.Sprint(pcieFunction.ID)
+	pciFunctionDeviceclass := fmt.Sprint(pcieFunction.DeviceClass)
+	pciFunctionType := fmt.Sprint(pcieFunction.FunctionType)
 	pciFunctionState := pcieFunction.Status.State
 	pciFunctionHealthState := pcieFunction.Status.Health
 

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -10,12 +10,6 @@ import (
 	"github.com/stmcginnis/gofish/redfish"
 )
 
-// A SystemCollector implements the prometheus.Collector.
-
-type systemMetric struct {
-	desc *prometheus.Desc
-}
-
 // SystemSubsystem is the system subsystem
 var (
 	SystemSubsystem                   = "system"
@@ -31,310 +25,75 @@ var (
 	SystemEthernetInterfaceLabelNames = []string{"hostname", "resource", "ethernet_interface", "ethernet_interface_id", "ethernet_interface_speed"}
 	SystemPCIeFunctionLabelNames      = []string{"hostname", "resource", "pcie_function_name", "pcie_function_id", "pci_function_deviceclass", "pci_function_type"}
 
-	systemMetrics = map[string]systemMetric{
-		"system_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "state"),
-				"system state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "health_state"),
-				"system health,1(OK),2(Warning),3(Critical)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_power_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "power_state"),
-				"system power state",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_memory_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_memory_state"),
-				"system overall memory state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_memory_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_memory_health_state"),
-				"system overall memory health,1(OK),2(Warning),3(Critical)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_memory_size": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_memory_size"),
-				"system total memory size, GiB",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_processor_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_processor_state"),
-				"system overall processor state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_processor_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_processor_health_state"),
-				"system overall processor health,1(OK),2(Warning),3(Critical)",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_total_processor_count": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "total_processor_count"),
-				"system total  processor count",
-				SystemLabelNames,
-				nil,
-			),
-		},
-		"system_memory_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "memory_state"),
-				"system memory state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemMemoryLabelNames,
-				nil,
-			),
-		},
-		"system_memory_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "memory_health_state"),
-				"system memory  health state,1(OK),2(Warning),3(Critical)",
-				SystemMemoryLabelNames,
-				nil,
-			),
-		},
-		"system_memory_capacity": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "memory_capacity"),
-				"system memory capacity, MiB",
-				SystemMemoryLabelNames,
-				nil,
-			),
-		},
-
-		"system_processor_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "processor_state"),
-				"system processor state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemProcessorLabelNames,
-				nil,
-			),
-		},
-		"system_processor_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "processor_health_state"),
-				"system processor  health state,1(OK),2(Warning),3(Critical)",
-				SystemProcessorLabelNames,
-				nil,
-			),
-		},
-		"system_processor_total_threads": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "processor_total_threads"),
-				"system processor total threads",
-				SystemProcessorLabelNames,
-				nil,
-			),
-		},
-		"system_processor_total_cores": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "processor_total_cores"),
-				"system processor total cores",
-				SystemProcessorLabelNames,
-				nil,
-			),
-		},
-		"system_simple_storage_device_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "simple_storage_device_state"),
-				"system simple storage device state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemDeviceLabelNames,
-				nil,
-			),
-		},
-		"system_simple_storage_device_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "simple_storage_device_health_state"),
-				"system simple storage device health state,1(OK),2(Warning),3(Critical)",
-				SystemDeviceLabelNames,
-				nil,
-			),
-		},
-		"system_storage_volume_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_volume_state"),
-				"system storage volume state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemVolumeLabelNames,
-				nil,
-			),
-		},
-		"system_storage_volume_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_volume_health_state"),
-				"system storage volume health state,1(OK),2(Warning),3(Critical)",
-				SystemVolumeLabelNames,
-				nil,
-			),
-		},
-		"system_storage_volume_capacity": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_volume_capacity"),
-				"system storage volume capacity,Bytes",
-				SystemVolumeLabelNames,
-				nil,
-			),
-		},
-		"system_storage_drive_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_drive_state"),
-				"system storage drive state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemDriveLabelNames,
-				nil,
-			),
-		},
-		"system_storage_drive_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_drive_health_state"),
-				"system storage volume health state,1(OK),2(Warning),3(Critical)",
-				SystemDriveLabelNames,
-				nil,
-			),
-		},
-		"system_storage_drive_capacity": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_drive_capacity"),
-				"system storage drive capacity,Bytes",
-				SystemDriveLabelNames,
-				nil,
-			),
-		},
-		"system_storage_controller_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_controller_state"),
-				"system storage controller state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemStorageControllerLabelNames,
-				nil,
-			),
-		},
-		"system_storage_controller_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "storage_controller_health_state"),
-				"system storage controller health state,1(OK),2(Warning),3(Critical)",
-				SystemStorageControllerLabelNames,
-				nil,
-			),
-		},
-		"system_pcie_device_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "pcie_device_state"),
-				"system pcie device state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemPCIeDeviceLabelNames,
-				nil,
-			),
-		},
-		"system_pcie_device_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "pcie_device_health_state"),
-				"system pcie device health state,1(OK),2(Warning),3(Critical)",
-				SystemPCIeDeviceLabelNames,
-				nil,
-			),
-		},
-		"system_pcie_function_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "pcie_function_state"),
-				"system pcie device state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemPCIeFunctionLabelNames,
-				nil,
-			),
-		},
-		"system_pcie_function_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "pcie_function_health_state"),
-				"system pcie device health state,1(OK),2(Warning),3(Critical)",
-				SystemPCIeFunctionLabelNames,
-				nil,
-			),
-		},
-		"system_network_interface_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "network_interface_state"),
-				"system network interface state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemNetworkInterfaceLabelNames,
-				nil,
-			),
-		},
-		"system_network_interface_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "network_interface_health_state"),
-				"system network interface health state,1(OK),2(Warning),3(Critical)",
-				SystemNetworkInterfaceLabelNames,
-				nil,
-			),
-		},
-		"system_ethernet_interface_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "ethernet_interface_state"),
-				"system ethernet interface state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)",
-				SystemEthernetInterfaceLabelNames,
-				nil,
-			),
-		},
-		"system_ethernet_interface_health_state": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "ethernet_interface_health_state"),
-				"system ethernet interface health state,1(OK),2(Warning),3(Critical)",
-				SystemEthernetInterfaceLabelNames,
-				nil,
-			),
-		},
-		"system_ethernet_interface_link_status": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "ethernet_interface_link_status"),
-				"system ethernet interface link status，1(LinkUp),2(NoLink),3(LinkDown)",
-				SystemEthernetInterfaceLabelNames,
-				nil,
-			),
-		},
-		"system_ethernet_interface_link_enabled": {
-			desc: prometheus.NewDesc(
-				prometheus.BuildFQName(namespace, SystemSubsystem, "ethernet_interface_link_enabled"),
-				"system ethernet interface if the link is enabled",
-				SystemEthernetInterfaceLabelNames,
-				nil,
-			),
-		},
-	}
+	systemMetrics = createSystemMetricMap()
 )
 
-// SystemCollector implemented prometheus.Collector
+// SystemCollector implements the prometheus.Collector.
 type SystemCollector struct {
-	redfishClient           *gofish.APIClient
-	metrics                 map[string]systemMetric
-	collectorScrapeStatus   *prometheus.GaugeVec
-	collectorScrapeDuration *prometheus.SummaryVec
-	Log                     *log.Entry
+	redfishClient *gofish.APIClient
+	metrics       map[string]Metric
+	prometheus.Collector
+	collectorScrapeStatus *prometheus.GaugeVec
+	Log                   *log.Entry
+}
+
+func createSystemMetricMap() map[string]Metric {
+	systemMetrics := make(map[string]Metric)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "state", fmt.Sprintf("system state,%s", CommonStateHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "health_state", fmt.Sprintf("system health,%s", CommonHealthHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "power_state", "system power state", SystemLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_memory_state", fmt.Sprintf("system overall memory state,%s", CommonStateHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_memory_health_state", fmt.Sprintf("system overall memory health,%s", CommonHealthHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_memory_size", "system total memory size, GiB", SystemLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_processor_state", fmt.Sprintf("system overall processor state,%s", CommonStateHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_processor_health_state", fmt.Sprintf("system overall processor health,%s", CommonHealthHelp), SystemLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "total_processor_count", "system total processor count", SystemLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "memory_state", fmt.Sprintf("system memory state,%s", CommonStateHelp), SystemMemoryLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "memory_health_state", fmt.Sprintf("system memory health state,%s", CommonHealthHelp), SystemMemoryLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "memory_capacity", "system memory capacity, MiB", SystemMemoryLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_state", fmt.Sprintf("system processor state,%s", CommonStateHelp), SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_health_state", fmt.Sprintf("system processor health state,%s", CommonHealthHelp), SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_threads", "system processor total threads", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_cores", "system processor total cores", SystemProcessorLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "simple_storage_device_state", fmt.Sprintf("system simple storage device state,%s", CommonStateHelp), SystemDeviceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "simple_storage_device_health_state", fmt.Sprintf("system simple storage device health state,%s", CommonHealthHelp), SystemDeviceLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_state", fmt.Sprintf("system storage volume state,%s", CommonStateHelp), SystemVolumeLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_health_state", fmt.Sprintf("system storage volume health state,%s", CommonHealthHelp), SystemVolumeLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_capacity", "system storage volume capacity, Bytes", SystemVolumeLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_drive_state", fmt.Sprintf("system storage drive state,%s", CommonStateHelp), SystemDriveLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_drive_health_state", fmt.Sprintf("system storage drive health state,%s", CommonHealthHelp), SystemDriveLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_drive_capacity", "system storage drive capacity, Bytes", SystemDriveLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_controller_state", fmt.Sprintf("system storage controller state,%s", CommonStateHelp), SystemStorageControllerLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "storage_controller_health_state", fmt.Sprintf("system storage controller health state,%s", CommonHealthHelp), SystemStorageControllerLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "pcie_device_state", fmt.Sprintf("system pcie device state,%s", CommonStateHelp), SystemPCIeDeviceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "pcie_device_health_state", fmt.Sprintf("system pcie device health state,%s", CommonHealthHelp), SystemPCIeDeviceLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "pcie_function_state", fmt.Sprintf("system pcie function state,%s", CommonStateHelp), SystemPCIeFunctionLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "pcie_function_health_state", fmt.Sprintf("system pcie device function state,%s", CommonHealthHelp), SystemPCIeFunctionLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "network_interface_state", fmt.Sprintf("system network interface state,%s", CommonStateHelp), SystemNetworkInterfaceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "network_interface_health_state", fmt.Sprintf("system network interface health state,%s", CommonHealthHelp), SystemNetworkInterfaceLabelNames)
+
+	addToMetricMap(systemMetrics, SystemSubsystem, "ethernet_interface_state", fmt.Sprintf("system ethernet interface state,%s", CommonStateHelp), SystemEthernetInterfaceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "ethernet_interface_health_state", fmt.Sprintf("system ethernet interface health state,%s", CommonHealthHelp), SystemEthernetInterfaceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "ethernet_interface_link_status", fmt.Sprintf("system ethernet interface link status,%s", CommonLinkHelp), SystemEthernetInterfaceLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "ethernet_interface_link_enabled", "system ethernet interface if the link is enabled", SystemEthernetInterfaceLabelNames)
+
+	return systemMetrics
 }
 
 // NewSystemCollector returns a collector that collecting memory statistics
-func NewSystemCollector(namespace string, redfishClient *gofish.APIClient, logger *log.Entry) *SystemCollector {
+func NewSystemCollector(redfishClient *gofish.APIClient, logger *log.Entry) *SystemCollector {
 	return &SystemCollector{
 		redfishClient: redfishClient,
 		metrics:       systemMetrics,
@@ -358,7 +117,6 @@ func (s *SystemCollector) Describe(ch chan<- *prometheus.Desc) {
 		ch <- metric.desc
 	}
 	s.collectorScrapeStatus.Describe(ch)
-
 }
 
 // Collect implements prometheus.Collector.
@@ -397,25 +155,20 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 			if systemPowerStateValue, ok := parseCommonPowerState(systemPowerState); ok {
 				ch <- prometheus.MustNewConstMetric(s.metrics["system_power_state"].desc, prometheus.GaugeValue, systemPowerStateValue, systemLabelValues...)
-
 			}
 			if systemTotalProcessorsStateValue, ok := parseCommonStatusState(systemTotalProcessorsState); ok {
 				ch <- prometheus.MustNewConstMetric(s.metrics["system_total_processor_state"].desc, prometheus.GaugeValue, systemTotalProcessorsStateValue, systemLabelValues...)
-
 			}
 			if systemTotalProcessorsHealthStateValue, ok := parseCommonStatusHealth(systemTotalProcessorsHealthState); ok {
 				ch <- prometheus.MustNewConstMetric(s.metrics["system_total_processor_health_state"].desc, prometheus.GaugeValue, systemTotalProcessorsHealthStateValue, systemLabelValues...)
-
 			}
 			ch <- prometheus.MustNewConstMetric(s.metrics["system_total_processor_count"].desc, prometheus.GaugeValue, float64(systemTotalProcessorCount), systemLabelValues...)
 
 			if systemTotalMemoryStateValue, ok := parseCommonStatusState(systemTotalMemoryState); ok {
 				ch <- prometheus.MustNewConstMetric(s.metrics["system_total_memory_state"].desc, prometheus.GaugeValue, systemTotalMemoryStateValue, systemLabelValues...)
-
 			}
 			if systemTotalMemoryHealthStateValue, ok := parseCommonStatusHealth(systemTotalMemoryHealthState); ok {
 				ch <- prometheus.MustNewConstMetric(s.metrics["system_total_memory_health_state"].desc, prometheus.GaugeValue, systemTotalMemoryHealthStateValue, systemLabelValues...)
-
 			}
 			ch <- prometheus.MustNewConstMetric(s.metrics["system_total_memory_size"].desc, prometheus.GaugeValue, float64(systemTotalMemoryAmount), systemLabelValues...)
 
@@ -438,7 +191,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 
 				for _, memory := range memories {
 					go parseMemory(ch, systemHostName, memory, wg1)
-
 				}
 			}
 
@@ -457,10 +209,9 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 				wg2.Add(len(processors))
 
 				for _, processor := range processors {
-					go parsePorcessor(ch, systemHostName, processor, wg2)
+					go parseProcessor(ch, systemHostName, processor, wg2)
 
 				}
-
 			}
 
 			//process storage
@@ -551,7 +302,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 				for _, networkInterface := range networkInterfaces {
 					go parseNetworkInterface(ch, systemHostName, networkInterface, wg6)
 				}
-
 			}
 
 			//process ethernetinterfaces
@@ -597,6 +347,7 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 					go parsePcieFunction(ch, systemHostName, pcieFunction, wg9)
 				}
 			}
+
 			systemLogContext.Info("collector scrape completed")
 		}
 		s.collectorScrapeStatus.WithLabelValues("system").Set(float64(1))
@@ -615,17 +366,15 @@ func parseMemory(ch chan<- prometheus.Metric, systemHostName string, memory *red
 	systemMemoryLabelValues := []string{systemHostName, "memory", memoryName, memoryID}
 	if memoryStateValue, ok := parseCommonStatusState(memoryState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_memory_state"].desc, prometheus.GaugeValue, memoryStateValue, systemMemoryLabelValues...)
-
 	}
 	if memoryHealthStateValue, ok := parseCommonStatusHealth(memoryHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_memory_health_state"].desc, prometheus.GaugeValue, memoryHealthStateValue, systemMemoryLabelValues...)
-
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_memory_capacity"].desc, prometheus.GaugeValue, float64(memoryCapacityMiB), systemMemoryLabelValues...)
 
 }
 
-func parsePorcessor(ch chan<- prometheus.Metric, systemHostName string, processor *redfish.Processor, wg *sync.WaitGroup) {
+func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processor *redfish.Processor, wg *sync.WaitGroup) {
 	defer wg.Done()
 	processorName := processor.Name
 	processorID := processor.ID
@@ -638,11 +387,9 @@ func parsePorcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 
 	if processorStateValue, ok := parseCommonStatusState(processorState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_state"].desc, prometheus.GaugeValue, processorStateValue, systemProcessorLabelValues...)
-
 	}
 	if processorHelathStateValue, ok := parseCommonStatusHealth(processorHelathState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_health_state"].desc, prometheus.GaugeValue, processorHelathStateValue, systemProcessorLabelValues...)
-
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_threads"].desc, prometheus.GaugeValue, float64(processorTotalThreads), systemProcessorLabelValues...)
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_cores"].desc, prometheus.GaugeValue, float64(processorTotalCores), systemProcessorLabelValues...)
@@ -657,11 +404,9 @@ func parseVolume(ch chan<- prometheus.Metric, systemHostName string, volume *red
 	systemVolumeLabelValues := []string{systemHostName, "volume", volumeName, volumeID}
 	if volumeStateValue, ok := parseCommonStatusState(volumeState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_volume_state"].desc, prometheus.GaugeValue, volumeStateValue, systemVolumeLabelValues...)
-
 	}
 	if volumeHealthStateValue, ok := parseCommonStatusHealth(volumeHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_volume_health_state"].desc, prometheus.GaugeValue, volumeHealthStateValue, systemVolumeLabelValues...)
-
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_volume_capacity"].desc, prometheus.GaugeValue, float64(volumeCapacityBytes), systemVolumeLabelValues...)
 }
@@ -688,17 +433,14 @@ func parseDrive(ch chan<- prometheus.Metric, systemHostName string, drive *redfi
 	systemdriveLabelValues := []string{systemHostName, "drive", driveName, driveID}
 	if driveStateValue, ok := parseCommonStatusState(driveState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_drive_state"].desc, prometheus.GaugeValue, driveStateValue, systemdriveLabelValues...)
-
 	}
 	if driveHealthStateValue, ok := parseCommonStatusHealth(driveHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_drive_health_state"].desc, prometheus.GaugeValue, driveHealthStateValue, systemdriveLabelValues...)
-
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_storage_drive_capacity"].desc, prometheus.GaugeValue, float64(driveCapacityBytes), systemdriveLabelValues...)
 }
 
 func parsePcieDevice(ch chan<- prometheus.Metric, systemHostName string, pcieDevice *redfish.PCIeDevice, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 	pcieDeviceName := pcieDevice.Name
 	pcieDeviceID := pcieDevice.ID
@@ -711,11 +453,9 @@ func parsePcieDevice(ch chan<- prometheus.Metric, systemHostName string, pcieDev
 
 	if pcieStateVaule, ok := parseCommonStatusState(pcieDeviceState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_pcie_device_state"].desc, prometheus.GaugeValue, pcieStateVaule, systemPCIeDeviceLabelValues...)
-
 	}
 	if pcieHealthStateVaule, ok := parseCommonStatusHealth(pcieDeviceHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_pcie_device_health_state"].desc, prometheus.GaugeValue, pcieHealthStateVaule, systemPCIeDeviceLabelValues...)
-
 	}
 }
 
@@ -729,11 +469,9 @@ func parseNetworkInterface(ch chan<- prometheus.Metric, systemHostName string, n
 
 	if networknetworkInterfaceStateVaule, ok := parseCommonStatusState(networkInterfaceState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_network_interface_state"].desc, prometheus.GaugeValue, networknetworkInterfaceStateVaule, systemNetworkInterfaceLabelValues...)
-
 	}
 	if networknetworkInterfaceHealthStateVaule, ok := parseCommonStatusHealth(networkInterfaceHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_network_interface_health_state"].desc, prometheus.GaugeValue, networknetworkInterfaceHealthStateVaule, systemNetworkInterfaceLabelValues...)
-
 	}
 }
 
@@ -751,23 +489,18 @@ func parseEthernetInterface(ch chan<- prometheus.Metric, systemHostName string, 
 	systemEthernetInterfaceLabelValues := []string{systemHostName, "ethernet_interface", ethernetInterfaceName, ethernetInterfaceID, ethernetInterfaceSpeed}
 	if ethernetInterfaceStateValue, ok := parseCommonStatusState(ethernetInterfaceState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_ethernet_interface_state"].desc, prometheus.GaugeValue, ethernetInterfaceStateValue, systemEthernetInterfaceLabelValues...)
-
 	}
 	if ethernetInterfaceHealthStateValue, ok := parseCommonStatusHealth(ethernetInterfaceHealthState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_ethernet_interface_health_state"].desc, prometheus.GaugeValue, ethernetInterfaceHealthStateValue, systemEthernetInterfaceLabelValues...)
 	}
 	if ethernetInterfaceLinkStatusValue, ok := parseLinkStatus(ethernetInterfaceLinkStatus); ok {
-
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_ethernet_interface_link_status"].desc, prometheus.GaugeValue, ethernetInterfaceLinkStatusValue, systemEthernetInterfaceLabelValues...)
-
 	}
 
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_ethernet_interface_link_enabled"].desc, prometheus.GaugeValue, boolToFloat64(ethernetInterfaceEnabled), systemEthernetInterfaceLabelValues...)
-
 }
 
 func parsePcieFunction(ch chan<- prometheus.Metric, systemHostName string, pcieFunction *redfish.PCIeFunction, wg *sync.WaitGroup) {
-
 	defer wg.Done()
 	pcieFunctionName := pcieFunction.Name
 	pcieFunctionID := fmt.Sprint("%v", pcieFunction.ID)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/common v0.26.0
 	github.com/prometheus/exporter-toolkit v0.5.0
-	github.com/stmcginnis/gofish v0.13.0
+	github.com/stmcginnis/gofish v0.14.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/stmcginnis/gofish v0.13.0 h1:qq6q3yNt9vw7ZuJxiw87hq9+BdPLsuRQBwl+XoZSz60=
-github.com/stmcginnis/gofish v0.13.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
+github.com/stmcginnis/gofish v0.14.0 h1:geECNAiG33JDB2x2xDkerpOOuXFqxp5YP3EFE3vd5iM=
+github.com/stmcginnis/gofish v0.14.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=


### PR DESCRIPTION
I'd like to propose the changes to include metrics from log services.
I also refactored the code, first of all to avoid duplicating the logic for parsing log services and log entries in each collector.
And I fixed all linter issues except for unused methods and variables.
