### PR TITLE
Fix "panic: send on closed channel" 

### DIFF
--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -398,6 +398,7 @@ func parseNetworkAdapter(ch chan<- prometheus.Metric, chassisID string, networkA
 		for _, networkPort := range networkPorts {
 			go parseNetworkPort(ch, chassisID, networkPort, networkAdapterName, networkAdapterID, wg6)
 		}
+		wg6.Wait()
 	}
 	return nil
 }

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -182,6 +182,17 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			// get system OdataID
 			//systemOdataID := system.ODataID
 
+			wg1 := &sync.WaitGroup{}
+			wg2 := &sync.WaitGroup{}
+			wg3 := &sync.WaitGroup{}
+			wg4 := &sync.WaitGroup{}
+			wg5 := &sync.WaitGroup{}
+			wg6 := &sync.WaitGroup{}
+			wg7 := &sync.WaitGroup{}
+			wg8 := &sync.WaitGroup{}
+			wg9 := &sync.WaitGroup{}
+			wg10 := &sync.WaitGroup{}
+
 			// process memory metrics
 			// construct memory Link
 			//memoriesLink := fmt.Sprintf("%sMemory/", systemOdataID)
@@ -193,7 +204,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if memories == nil {
 				systemLogContext.WithField("operation", "system.Memory()").Info("no memory data found")
 			} else {
-				wg1 := &sync.WaitGroup{}
 				wg1.Add(len(memories))
 
 				for _, memory := range memories {
@@ -212,7 +222,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if processors == nil {
 				systemLogContext.WithField("operation", "system.Processors()").Info("no processor data found")
 			} else {
-				wg2 := &sync.WaitGroup{}
 				wg2.Add(len(processors))
 
 				for _, processor := range processors {
@@ -235,7 +244,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 					if volumes, err := storage.Volumes(); err != nil {
 						systemLogContext.WithField("operation", "system.Volumes()").WithError(err).Error("error getting storage data from system")
 					} else {
-						wg3 := &sync.WaitGroup{}
 						wg3.Add(len(volumes))
 
 						for _, volume := range volumes {
@@ -249,7 +257,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 					} else if drives == nil {
 						systemLogContext.WithFields(log.Fields{"operation": "system.Drives()", "storage": storage.ID}).Info("no drive data found")
 					} else {
-						wg4 := &sync.WaitGroup{}
 						wg4.Add(len(drives))
 						for _, drive := range drives {
 							go parseDrive(ch, systemHostName, drive, wg4)
@@ -290,7 +297,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if pcieDevices == nil {
 				systemLogContext.WithField("operation", "system.PCIeDevices()").Info("no PCI-E device data found")
 			} else {
-				wg5 := &sync.WaitGroup{}
 				wg5.Add(len(pcieDevices))
 				for _, pcieDevice := range pcieDevices {
 					go parsePcieDevice(ch, systemHostName, pcieDevice, wg5)
@@ -304,7 +310,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if networkInterfaces == nil {
 				systemLogContext.WithField("operation", "system.NetworkInterfaces()").Info("no network interface data found")
 			} else {
-				wg6 := &sync.WaitGroup{}
 				wg6.Add(len(networkInterfaces))
 				for _, networkInterface := range networkInterfaces {
 					go parseNetworkInterface(ch, systemHostName, networkInterface, wg6)
@@ -318,7 +323,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if ethernetInterfaces == nil {
 				systemLogContext.WithField("operation", "system.PCIeDevices()").Info("no ethernet interface data found")
 			} else {
-				wg7 := &sync.WaitGroup{}
 				wg7.Add(len(ethernetInterfaces))
 				for _, ethernetInterface := range ethernetInterfaces {
 					go parseEthernetInterface(ch, systemHostName, ethernetInterface, wg7)
@@ -334,7 +338,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else {
 				for _, simpleStorage := range simpleStorages {
 					devices := simpleStorage.Devices
-					wg8 := &sync.WaitGroup{}
 					wg8.Add(len(devices))
 					for _, device := range devices {
 						go parseDevice(ch, systemHostName, device, wg8)
@@ -348,7 +351,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if pcieFunctions == nil {
 				systemLogContext.WithField("operation", "system.PCIeFunctions()").Info("no PCI-E device function data found")
 			} else {
-				wg9 := &sync.WaitGroup{}
 				wg9.Add(len(pcieFunctions))
 				for _, pcieFunction := range pcieFunctions {
 					go parsePcieFunction(ch, systemHostName, pcieFunction, wg9)
@@ -362,7 +364,6 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 			} else if logServices == nil {
 				systemLogContext.WithField("operation", "system.LogServices()").Info("no log services found")
 			} else {
-				wg10 := &sync.WaitGroup{}
 				wg10.Add(len(logServices))
 
 				for _, logService := range logServices {
@@ -371,6 +372,17 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) {
 					}
 				}
 			}
+
+			wg1.Wait()
+			wg2.Wait()
+			wg3.Wait()
+			wg4.Wait()
+			wg5.Wait()
+			wg6.Wait()
+			wg7.Wait()
+			wg8.Wait()
+			wg9.Wait()
+			wg10.Wait()
 
 			systemLogContext.Info("collector scrape completed")
 		}


### PR DESCRIPTION
This PR seeks to fix issues like the following:

```
2022/04/20 19:31:21  info collector scrape completed System=System.Embedded.1 app=redfish_exporter collector=SystemCollector target=10.208.16.33
panic: send on closed channel

goroutine 916 [running]:
github.com/jenningsloy318/redfish_exporter/collector.parseEthernetInterface(0xc00049cc00, 0x0, 0x0, 0xc000152dc0, 0xc00056e264)
	/go/src/github.com/jenningsloy318/redfish_exporter/collector/system_collector.go:684 +0x465
created by github.com/jenningsloy318/redfish_exporter/collector.(*SystemCollector).Collect
	/go/src/github.com/jenningsloy318/redfish_exporter/collector/system_collector.go:532 +0xbdf
```

See https://github.com/jenningsloy318/redfish_exporter/issues/64 for examples of others who have encountered the same problem.

These issues occur, because the channel is closed before all `goroutines` have a chance to complete.  In order to avoid that, add a `Wait()` on each `WaitGroup` to block until `goroutines` complete.

In order to maximize parallel execution prior to blocking, initialize all `WaitGroups` in `system_collector` prior to walking the `System` tree.  Then, block with `Wait()` directives after all `goroutines` are executed.  The down side to this approach is that some `WaitGroups` may be created for resources that aren't present on a given system.  However, I believe it's worth it for the parallel execution.

I have been running a local version like this on my fleet for months on 1000s of servers without issue and haven't seen a `panic: send on closed channel` since.